### PR TITLE
Rmvb module has nothing to do with mp4 module, so the modules tag sho…

### DIFF
--- a/song-parser-mp4/pom.xml
+++ b/song-parser-mp4/pom.xml
@@ -4,10 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <version>1.0.0</version>
-    <modules>
-        <module>../song-parser-rmvb</module>
-    </modules>
-    <packaging>pom</packaging>
+
+    <packaging>jar</packaging>
 
     <groupId>com.xiaoshu.demo</groupId>
     <artifactId>song-parser-mp4</artifactId>


### PR DESCRIPTION
…uld be removed in mp4 pom.xml.

Anthor problem is mp4's packaging value is jar, not pom. Because it will be provided to other project.